### PR TITLE
add document type

### DIFF
--- a/py/shared/abstractions/document.py
+++ b/py/shared/abstractions/document.py
@@ -80,6 +80,7 @@ class DocumentType(str, Enum):
 
     # Video/GIF
     GIF = "gif"
+    MP4 = "mp4"
 
     # Word
     DOC = "doc"
@@ -90,6 +91,9 @@ class DocumentType(str, Enum):
     JS = "js"
     TS = "ts"
     CSS = "css"
+
+    # other type
+    UNKNOWN = "UNKNOWN"
 
 
 class Document(R2RSerializable):


### PR DESCRIPTION
### Objective  

To handle the ingestion and retrieval of video file types such as MP4. To support temporary processing workflows for undefined types.

### Additions to the `DocumentType` enum:  

* Added `MP4` as a new video file type.  
* Added `UNKNOWN` as a catch-all type for unspecified or unsupported document formats.  
